### PR TITLE
pawn 1.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,18 +2,28 @@ BIN_NAME=pawn
 BUILD_DIR=build
 SRC_DIR=src
 
-CXXFLAGS=-Wall -std=c++17 -O3 -march=native -flto
-LDFLAGS=-pthread -flto
+# Default arch
+ARCH = native
+
+# Compiler flags
+CXXFLAGS = -Wall -std=c++17 -O3 -flto -march=$(ARCH)
+LDFLAGS = -pthread -flto -march=$(ARCH)
+
+# Windows-specific stuff
+ifeq ($(OS), Windows_NT)
+	LDFLAGS += -static
+	BIN_NAME := $(BIN_NAME).exe
+endif
 
 SRC_FILES = $(shell find $(SRC_DIR) -name *.cpp)
 OBJ_FILES = $(SRC_FILES:%.cpp=$(BUILD_DIR)/%.o)
 DEP_FILES = $(OBJ_FILES:.o=.d)
 
-PSQT_SRC_FILE = "src/PieceSquareTables.cpp"
-PSQT_HEADER_FILE = "src/PieceSquareTables.hpp"
-PSQT_FILE = $(subst ",,$(word 3, $(shell grep PSQT_Default_File $(PSQT_HEADER_FILE))))
+# Find the network file to mark it as a dependency for the binary
+NET_HEADER_FILE = "src/PieceSquareTables.hpp"
+NET_FILE = $(subst ",,$(word 3, $(shell grep PSQT_Default_File $(NET_HEADER_FILE))))
 
-$(BUILD_DIR)/$(BIN_NAME) : $(OBJ_FILES) $(PSQT_FILE)
+$(BUILD_DIR)/$(BIN_NAME) : $(OBJ_FILES) $(NET_FILE)
 	$(CXX) $(OBJ_FILES) -o $@ $(LDFLAGS)
 
 -include $(DEP_FILES)

--- a/README.md
+++ b/README.md
@@ -3,22 +3,84 @@ A UCI alpha-beta chess engine, largely inspired by Stockfish.
 
 As with most UCI chess engines, `pawn` should be used with a compatible graphical user interface (such as [CuteChess](https://github.com/cutechess/cutechess)).
 
+The engine uses a hybrid evaluation function combining both handcrafted terms (such as material, mobility and king safety) and an efficiently updatable neural network for positional scores (derived from a set of trained PSQ tables in earlier versions).
+All training data has been generated in self-play at low depth using the tools in the branch [`data_gen`](https://github.com/ruicoelhopedro/pawn/tree/data_gen).
+The default network is embedded in the binary file with `incbin`.
+
+## Getting `pawn`
+The latest official version can be downloaded in the [Releases](https://github.com/ruicoelhopedro/pawn/releases) tab.
+Binaries for both Windows and Linux are available.
+For each platform, two 64-bit versions are provided: a generic version for most x86 processors (slower) and one with the instruction set from `haswell` (faster with BMI2, AVX2 and POPCNT, but may not be supported for older CPUs).
+
+For the most up-to-date (and likely stronger) version, it is recommended to compile directly from sources for the target architecture, as described below.
+
+### Compiling from sources
+To compile under Linux or Windows with MSYS2, simply call
+```
+make
+```
+in the root directory to generate an executable optimised for the building machine.
+The resulting binary and object files can be found in the `build` directory.
+Verify the signature of the binary by running the `bench` command and checking if the number of nodes searched matches the Bench field of the last commit message. 
+
+To compile generic binaries or to a specific architecture, use
+```
+make ARCH=target
+```
+where `target` is the target passed to `-march=`.
+
+
+## Progress
+
+The progression of `pawn` in self-play since the first public version is illustrated in the table below.
+The ratings are computed with `ordo` anchored at zero mean using the `noob_3moves` book and with TC 60+0.6.
+
+| Date     | Commit  |  Elo   | Error(+/-) |
+|----------|---------|--------|------------|
+| 23/02/11 | [`527fe63`](https://github.com/ruicoelhopedro/pawn/commit/527fe63b24f58b1230278c1f4dfc4541d0472f99) |  620.9 |       25.5 |
+| 23/01/31 | [`d7b26dc`](https://github.com/ruicoelhopedro/pawn/commit/d7b26dcab6ba7ff8bc451c17423a0cec31dd8d6a) |  602.4 |       23.6 |
+| 22/12/20 | [`ecf549f`](https://github.com/ruicoelhopedro/pawn/commit/ecf549f4d3c988fcf44b34402cdb534c71881056) |  409.5 |       20.2 |
+| 22/11/18 | [`c22a7e5`](https://github.com/ruicoelhopedro/pawn/commit/c22a7e526826ad10565cbddb49a907351f8e27ba) |  393.9 |       19.4 |
+| 22/10/06 | [`567797f`](https://github.com/ruicoelhopedro/pawn/commit/567797f0fbe1df386444df12e07462dc2305bb60) |  279.7 |       18.7 |
+| 22/09/23 | [`132140b`](https://github.com/ruicoelhopedro/pawn/commit/132140b23e018c82259061b46d8b4569ac429666) |  267.0 |       19.8 |
+| 22/08/30 | [`25607d9`](https://github.com/ruicoelhopedro/pawn/commit/25607d9b1d1357164d49438f95a81a78109930e2) |  232.9 |       19.1 |
+| 22/07/30 | [`638dc4c`](https://github.com/ruicoelhopedro/pawn/commit/638dc4cfe2b2b9d15832d5be6811d17989535185) |  174.2 |       18.4 |
+| 22/06/27 | [`069e93a`](https://github.com/ruicoelhopedro/pawn/commit/069e93aedd915f2826b06e838e727c915249591d) |   75.3 |       19.6 |
+| 22/05/27 | [`78c2f15`](https://github.com/ruicoelhopedro/pawn/commit/78c2f15ab191cb5ffc9e40244e6ec9bc807a0622) | -118.0 |       19.5 |
+| 22/04/27 | [`5fd6e1d`](https://github.com/ruicoelhopedro/pawn/commit/5fd6e1d74b4efdaf7c86044db5f6fd5c52dbcbb5) | -367.4 |       21.1 |
+| 22/03/18 | [`fa8e828`](https://github.com/ruicoelhopedro/pawn/commit/fa8e8281278eaad998446b8137db4a1708b05411) | -403.5 |       21.7 |
+| 22/02/28 | [`0a131bd`](https://github.com/ruicoelhopedro/pawn/commit/0a131bdb01c8d5cbfa1f68de349e5ca4bcb9dec8) | -424.8 |       21.8 |
+| 21/10/29 | [`61edb2a`](https://github.com/ruicoelhopedro/pawn/commit/61edb2a9417ed3b03ddfb8a667c883d55c44036d) | -436.4 |       22.0 |
+| 21/09/28 | [`cadf61b`](https://github.com/ruicoelhopedro/pawn/commit/cadf61b0049c37b06c14ef64b43b0eaa8cea0610) | -555.8 |       24.2 |
+| 21/08/31 | [`056c448`](https://github.com/ruicoelhopedro/pawn/commit/056c44850f6d74a993b1c1eee10a2809cd99c889) | -749.8 |       30.3 |
+
+
 ## UCI Options
 The following UCI options are supported:
 - #### Hash
   Size of the Hash Table, in MB (defaults to 16).
   
 - #### Threads
-  Number of threads to use during search (defaults to 1).
+  The number of threads to use during search (defaults to 1).
  
 - #### MultiPV
-  Number of principal variations (PV) to search (defaults to 1). This should be kept at 1 for best performance.
+  The number of principal variations (PV) to search (defaults to 1). This should be kept at 1 for best performance.
  
 - #### Ponder
   Allow the engine to think during the opponent's move (defaults to false). This requires the GUI to send the appropriate `go ponder`.
+ 
+- #### Move Overhead
+  Extra time to reserve for each move (defaults to 0). Increase if the engine flags due to communication delays.
+
+- #### Clear Hash
+  Button to clear the hash table.
+
+- #### PSQT_File
+  Path to the PSQT net file to use (empty by default). If empty falls back to the embedded network file.
+
   
 Furthermore, the following non-standard commands are available:
-- `board` - show representation of the current board;
+- `board` - show a representation of the current board;
 - `eval` - print some of the evaluation terms;
 - `test` - test the move generation, transposition tables, move orderers and legality checks of the engine;
 - `bench` - search a set of positions to obtain a signature. Optionally, the following syntax is available: `bench depth threads hash`. By default, calling `bench` is equivalent to `bench 13 1 16`.
@@ -32,11 +94,15 @@ Furthermore, the following non-standard commands are available:
 - Staged move generation for captures and quiet moves
 ### Evaluation
 - Tapered evaluation
-- Material and Piece-square tables (incrementally updated)
+- Material imbalance
+- Efficiently updatable positional neural network for positional score
 - Basic pawn structure
 - Mobility
 - Per-piece bonuses
 - King safety
+- Basic threats
+- Space
+- Basic endgame scaling functions
 ### Search
 - Principal Variation Search in a negamax framework
 - Quiescence search with SEE
@@ -50,14 +116,7 @@ Furthermore, the following non-standard commands are available:
 - Mate distance pruning
 - Basic Lazy SMP threading
 ### Move Ordering
-- MVV-LVA move ordering for captures
-- Killer moves and countermoves
+- MVV move ordering for captures
+- Killer moves
 - Quiet move ordering
-  - History heuristic with butterfly and piece-to boards
-
-## Compiling from sources
-To compile with `g++`, simply call
-```
-make
-```
-in the root directory. The resulting binary and object files can be found in the `build` directory.
+  - History heuristic with butterfly and 3-ply continuation piece-to boards

--- a/src/Thread.hpp
+++ b/src/Thread.hpp
@@ -43,7 +43,7 @@ class Thread
 protected:
     friend class Search::SearchData;
     friend class ThreadPool;
-    friend Score Evaluation::evaluation(const Board& board, EvalData& data, Thread& thread);
+    friend Score Evaluation::evaluation(const Board& board, Evaluation::EvalData& data, Thread& thread);
     Depth m_seldepth;
     Search::PvContainer m_pv;
     Histories m_histories;

--- a/src/UCI.cpp
+++ b/src/UCI.cpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <cctype>
 #include <iostream>
+#include <memory>
 #include <sstream>
 #include <string>
 
@@ -269,8 +270,8 @@ namespace UCI
         // Check if perft search
         if (perft_depth > 0)
         {
-            Histories hists;
-            int64_t nodes = Search::perft<true>(pool->position(), perft_depth, hists);
+            std::unique_ptr<Histories> hists;
+            int64_t nodes = Search::perft<true>(pool->position(), perft_depth, *hists);
             std::cout << "\nNodes searched: " << nodes << std::endl;
             return;
         }

--- a/src/UCI.cpp
+++ b/src/UCI.cpp
@@ -15,6 +15,9 @@
 
 namespace UCI
 {
+    constexpr std::string_view VERSION = "pawn 1.0";
+
+
     std::map<std::string, Option, OptionNameCompare> OptionsMap;
 
 
@@ -188,7 +191,7 @@ namespace UCI
 
     void uci(Stream& stream)
     {
-        std::cout << "id name pawn" << std::endl;
+        std::cout << "id name " << VERSION << std::endl;
         std::cout << "id author ruicoelhopedro" << std::endl;
 
         // Send options


### PR DESCRIPTION
The first official release of `pawn`, after over 1 year and a half in development.

The README has been updated with recent developments, additional guides and a progress table since the first public versions. Also, the Makefile has been adapted to ease building under Windows with mingw64.

Bench: 1860970

Closes #16