### PR TITLE
pawn 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The ratings are computed with `ordo` (anchored at zero for the first commit and 
 
 | Date     | Commit  |  Elo   | Error(+/-) |
 |----------|---------|--------|------------|
-| 23/10/06 | [`b079af8`](https://github.com/ruicoelhopedro/pawn/commit/b079af8fdb84dc061dbbed21ff29f60e7312bdaa) | 1619.7 |       17.9 |
+| 23/10/06 | [2.0](https://github.com/ruicoelhopedro/pawn/tree/v2.0)                                             | 1619.7 |       17.9 |
 | 23/08/31 | [`5a5ea8a`](https://github.com/ruicoelhopedro/pawn/commit/5a5ea8a6d999208831f9d12521a0d379450611ae) | 1556.2 |       17.8 |
 | 23/06/30 | [`b68c1df`](https://github.com/ruicoelhopedro/pawn/commit/b68c1dfbae0a5346401dff5655a87ff5f7555862) | 1549.4 |       17.8 |
 | 23/04/24 | [`c777eef`](https://github.com/ruicoelhopedro/pawn/commit/c777eef3af07889de88d51d830eb1e6f3c8423ba) | 1508.0 |       16.5 |

--- a/src/UCI.cpp
+++ b/src/UCI.cpp
@@ -17,7 +17,7 @@
 
 namespace UCI
 {
-    constexpr std::string_view VERSION = "pawn 1.0-dev";
+    constexpr std::string_view VERSION = "pawn 2.0";
 
 
     std::map<std::string, Option, OptionNameCompare> OptionsMap;


### PR DESCRIPTION
In this version, several new features have been included.
The evaluation now uses a full NNUE, which has been retrained from new datasets generated throughout. Compared with the previous hybrid classical/NNUE evaluation, the NNUE-only version is also faster.
Support for Syzygy endgame tablebases has been added, using Fathom for the probing code. The behaviour is described in the README.
Some aspects have also been simplified, and some additional Elo gains are expected under SMP conditions.

With these changes, compared to the 1.0 version, the measured Elo gain in self-play is in the order of 230 Elo, and the new version wins around 40 times more game pairs than it loses.

LTC vs pawn 1.0
Games: 2000/2000 Elo diff: 238.66 [226.25, 251.62] (95%)
W: 1245 L: 53 D: 702 Draw ratio: 35.1%
Pntl: [0, 20, 150, 448, 382]

Closes #18

No functional change