### PR TITLE
Switch to 16-bit accumulators and reorder network

### DIFF
--- a/src/NNUE.cpp
+++ b/src/NNUE.cpp
@@ -151,8 +151,8 @@ namespace NNUE
         for (std::size_t i = 0; i < NUM_ACCUMULATORS; i++)
         {
             // Clipped ReLU on the accumulators
-            int stm_acc = std::clamp(stm.m_net[i], 0, SCALE_FACTOR);
-            int ntm_acc = std::clamp(ntm.m_net[i], 0, SCALE_FACTOR);
+            int stm_acc = std::clamp(stm.m_net[i], int16_t(0), SCALE_FACTOR);
+            int ntm_acc = std::clamp(ntm.m_net[i], int16_t(0), SCALE_FACTOR);
 
             // Net output
             int j = i + NUM_ACCUMULATORS;

--- a/src/NNUE.hpp
+++ b/src/NNUE.hpp
@@ -2,15 +2,15 @@
 #include "Types.hpp"
 
 
-#define NNUE_Default_File "nnue-10427ad1e4e6.dat"
+#define NNUE_Default_File "nnue-e04a4f84c87d.dat"
 
 
 namespace NNUE
 {
 
     using Weight = int16_t;
-    using Feature = int;
-    constexpr int SCALE_FACTOR = 1024;
+    using Feature = uint16_t;
+    constexpr int16_t SCALE_FACTOR = 1024;
     constexpr std::size_t NUM_FEATURES = 20480;
     constexpr std::size_t NUM_ACCUMULATORS = 128;
     constexpr std::size_t NUM_MAX_ACTIVE_FEATURES = 30;
@@ -18,8 +18,8 @@ namespace NNUE
 
     struct Net
     {
-        Weight m_psqt[NUM_FEATURES][NUM_BUCKETS];
         Weight m_sparse_layer[NUM_FEATURES][NUM_ACCUMULATORS];
+        Weight m_psqt[NUM_FEATURES][NUM_BUCKETS];
         Weight m_bias[NUM_ACCUMULATORS];
         Weight m_dense[NUM_BUCKETS][2 * NUM_ACCUMULATORS];
         Weight m_dense_bias[NUM_BUCKETS];
@@ -27,8 +27,8 @@ namespace NNUE
 
     class Accumulator
     {
-        int m_net[NUM_ACCUMULATORS];
-        int m_psqt[NUM_BUCKETS];
+        int16_t m_net[NUM_ACCUMULATORS];
+        int16_t m_psqt[NUM_BUCKETS];
 
     public:
         Accumulator();


### PR DESCRIPTION
This uses smaller accumulators for the network, rendering a noticeable speedup. Furthermore, the weights of the network have been reordered to align with the accumulator's order.

STC:
LLR:  2.97/2.94<0.00, 10.00> Elo diff: 9.91 [3.04, 16.79] (95%)         
Games: 2350 W: 331 L: 264 D: 1755 Draw ratio: 74.7% 
Pntl: [10, 200, 697, 249, 19]

No functional change
