### PR TITLE
Version 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # pawn
 A UCI alpha-beta chess engine, largely inspired by Stockfish.
 
-As with most UCI chess engines, `pawn` should be used with a compatible graphical user interface (such as [CuteChess](https://github.com/cutechess/cutechess)).
+As with most UCI chess engines, `pawn` should be used with a compatible graphical user interface (such as [CuteChess](https://github.com/cutechess/cutechess)). It plays both standard chess and Chess960.
 
 The engine uses an efficiently updatable neural network (NNUE) for evaluation.
 Currently, the net is shallow with a single 256-neuron layer and 4 output buckets (selected according to the number of pieces on the board).
@@ -38,30 +38,32 @@ where `target` is the target passed to `-march=`.
 The progression of `pawn` in self-play since the first public version is illustrated in the table below.
 The ratings are computed with `ordo` (anchored at zero for the first commit and with errors relative to pool average) using the `noob_3moves` book under LTC conditions (single-thread with TC 60+0.6 and 64MB hash).
 
-| Date     | Commit  |  Elo   | Error(+/-) |
-|----------|---------|--------|------------|
-| 23/10/06 | [2.0](https://github.com/ruicoelhopedro/pawn/tree/v2.0)                                             | 1619.7 |       17.9 |
-| 23/08/31 | [`5a5ea8a`](https://github.com/ruicoelhopedro/pawn/commit/5a5ea8a6d999208831f9d12521a0d379450611ae) | 1556.2 |       17.8 |
-| 23/06/30 | [`b68c1df`](https://github.com/ruicoelhopedro/pawn/commit/b68c1dfbae0a5346401dff5655a87ff5f7555862) | 1549.4 |       17.8 |
-| 23/04/24 | [`c777eef`](https://github.com/ruicoelhopedro/pawn/commit/c777eef3af07889de88d51d830eb1e6f3c8423ba) | 1508.0 |       16.5 |
-| 23/03/12 | [1.0](https://github.com/ruicoelhopedro/pawn/tree/v1.0)                                             | 1387.7 |       16.1 |
-| 23/02/11 | [`527fe63`](https://github.com/ruicoelhopedro/pawn/commit/527fe63b24f58b1230278c1f4dfc4541d0472f99) | 1369.7 |       15.5 |
-| 23/01/31 | [`d7b26dc`](https://github.com/ruicoelhopedro/pawn/commit/d7b26dcab6ba7ff8bc451c17423a0cec31dd8d6a) | 1350.6 |       15.3 |
-| 22/12/20 | [`ecf549f`](https://github.com/ruicoelhopedro/pawn/commit/ecf549f4d3c988fcf44b34402cdb534c71881056) | 1161.2 |       13.8 |
-| 22/11/18 | [`c22a7e5`](https://github.com/ruicoelhopedro/pawn/commit/c22a7e526826ad10565cbddb49a907351f8e27ba) | 1147.1 |       14.1 |
-| 22/10/06 | [`567797f`](https://github.com/ruicoelhopedro/pawn/commit/567797f0fbe1df386444df12e07462dc2305bb60) | 1026.7 |       14.2 |
-| 22/09/23 | [`132140b`](https://github.com/ruicoelhopedro/pawn/commit/132140b23e018c82259061b46d8b4569ac429666) | 1016.9 |       17.0 |
-| 22/08/30 | [`25607d9`](https://github.com/ruicoelhopedro/pawn/commit/25607d9b1d1357164d49438f95a81a78109930e2) |  982.8 |       16.8 |
-| 22/07/30 | [`638dc4c`](https://github.com/ruicoelhopedro/pawn/commit/638dc4cfe2b2b9d15832d5be6811d17989535185) |  924.1 |       17.1 |
-| 22/06/27 | [`069e93a`](https://github.com/ruicoelhopedro/pawn/commit/069e93aedd915f2826b06e838e727c915249591d) |  825.1 |       17.6 |
-| 22/05/27 | [`78c2f15`](https://github.com/ruicoelhopedro/pawn/commit/78c2f15ab191cb5ffc9e40244e6ec9bc807a0622) |  631.8 |       19.3 |
-| 22/04/27 | [`5fd6e1d`](https://github.com/ruicoelhopedro/pawn/commit/5fd6e1d74b4efdaf7c86044db5f6fd5c52dbcbb5) |  382.4 |       21.6 |
-| 22/03/18 | [`fa8e828`](https://github.com/ruicoelhopedro/pawn/commit/fa8e8281278eaad998446b8137db4a1708b05411) |  346.3 |       21.4 |
-| 22/02/28 | [`0a131bd`](https://github.com/ruicoelhopedro/pawn/commit/0a131bdb01c8d5cbfa1f68de349e5ca4bcb9dec8) |  325.0 |       22.0 |
-| 21/10/29 | [`61edb2a`](https://github.com/ruicoelhopedro/pawn/commit/61edb2a9417ed3b03ddfb8a667c883d55c44036d) |  313.4 |       21.9 |
-| 21/09/28 | [`cadf61b`](https://github.com/ruicoelhopedro/pawn/commit/cadf61b0049c37b06c14ef64b43b0eaa8cea0610) |  194.0 |       23.9 |
-| 21/08/31 | [`056c448`](https://github.com/ruicoelhopedro/pawn/commit/056c44850f6d74a993b1c1eee10a2809cd99c889) |    0.0 |       30.3 |
-
+| Date     | Commit  |   Elo   | Error(+/-) |
+|----------|---------|---------|------------|
+| 24/01/12 | [3.0](https://github.com/ruicoelhopedro/pawn/tree/v3.0)                                             |   349.8 |       19.8 |
+| 23/11/30 | [`e276c44`](https://github.com/ruicoelhopedro/pawn/commit/e276c441d62ea08995ba03df3b54bd1ee95882fe) |   296.8 |       19.7 |
+| 23/10/31 | [`795d3c0`](https://github.com/ruicoelhopedro/pawn/commit/795d3c08066449789ab28f10c48c8c057210ef85) |   288.2 |       19.5 |
+| 23/10/06 | [2.0](https://github.com/ruicoelhopedro/pawn/tree/v2.0)                                             |   235.2 |       15.2 |
+| 23/08/31 | [`5a5ea8a`](https://github.com/ruicoelhopedro/pawn/commit/5a5ea8a6d999208831f9d12521a0d379450611ae) |   169.9 |       15.8 |
+| 23/06/30 | [`b68c1df`](https://github.com/ruicoelhopedro/pawn/commit/b68c1dfbae0a5346401dff5655a87ff5f7555862) |   163.4 |       15.7 |
+| 23/04/24 | [`c777eef`](https://github.com/ruicoelhopedro/pawn/commit/c777eef3af07889de88d51d830eb1e6f3c8423ba) |   121.7 |       14.6 |
+| 23/03/12 | [1.0](https://github.com/ruicoelhopedro/pawn/tree/v1.0)                                             |     0.0 |       14.0 |
+| 23/02/11 | [`527fe63`](https://github.com/ruicoelhopedro/pawn/commit/527fe63b24f58b1230278c1f4dfc4541d0472f99) |   -17.5 |       15.0 |
+| 23/01/31 | [`d7b26dc`](https://github.com/ruicoelhopedro/pawn/commit/d7b26dcab6ba7ff8bc451c17423a0cec31dd8d6a) |   -36.5 |       15.0 |
+| 22/12/20 | [`ecf549f`](https://github.com/ruicoelhopedro/pawn/commit/ecf549f4d3c988fcf44b34402cdb534c71881056) |  -226.0 |       14.2 |
+| 22/11/18 | [`c22a7e5`](https://github.com/ruicoelhopedro/pawn/commit/c22a7e526826ad10565cbddb49a907351f8e27ba) |  -240.1 |       13.8 |
+| 22/10/06 | [`567797f`](https://github.com/ruicoelhopedro/pawn/commit/567797f0fbe1df386444df12e07462dc2305bb60) |  -360.4 |       14.3 |
+| 22/09/23 | [`132140b`](https://github.com/ruicoelhopedro/pawn/commit/132140b23e018c82259061b46d8b4569ac429666) |  -370.2 |       16.9 |
+| 22/08/30 | [`25607d9`](https://github.com/ruicoelhopedro/pawn/commit/25607d9b1d1357164d49438f95a81a78109930e2) |  -404.3 |       17.1 |
+| 22/07/30 | [`638dc4c`](https://github.com/ruicoelhopedro/pawn/commit/638dc4cfe2b2b9d15832d5be6811d17989535185) |  -463.1 |       17.5 |
+| 22/06/27 | [`069e93a`](https://github.com/ruicoelhopedro/pawn/commit/069e93aedd915f2826b06e838e727c915249591d) |  -562.0 |       18.4 |
+| 22/05/27 | [`78c2f15`](https://github.com/ruicoelhopedro/pawn/commit/78c2f15ab191cb5ffc9e40244e6ec9bc807a0622) |  -755.4 |       19.6 |
+| 22/04/27 | [`5fd6e1d`](https://github.com/ruicoelhopedro/pawn/commit/5fd6e1d74b4efdaf7c86044db5f6fd5c52dbcbb5) | -1004.7 |       22.6 |
+| 22/03/18 | [`fa8e828`](https://github.com/ruicoelhopedro/pawn/commit/fa8e8281278eaad998446b8137db4a1708b05411) | -1040.8 |       22.6 |
+| 22/02/28 | [`0a131bd`](https://github.com/ruicoelhopedro/pawn/commit/0a131bdb01c8d5cbfa1f68de349e5ca4bcb9dec8) | -1062.2 |       22.7 |
+| 21/10/29 | [`61edb2a`](https://github.com/ruicoelhopedro/pawn/commit/61edb2a9417ed3b03ddfb8a667c883d55c44036d) | -1073.7 |       22.6 |
+| 21/09/28 | [`cadf61b`](https://github.com/ruicoelhopedro/pawn/commit/cadf61b0049c37b06c14ef64b43b0eaa8cea0610) | -1193.2 |       24.8 |
+| 21/08/31 | [`056c448`](https://github.com/ruicoelhopedro/pawn/commit/056c44850f6d74a993b1c1eee10a2809cd99c889) | -1387.1 |       30.4 |
 
 ## UCI Options
 The following UCI options are supported:

--- a/src/UCI.cpp
+++ b/src/UCI.cpp
@@ -17,7 +17,7 @@
 
 namespace UCI
 {
-    constexpr std::string_view VERSION = "pawn 2.0-dev";
+    constexpr std::string_view VERSION = "pawn 3.0";
 
 
     std::map<std::string, Option, OptionNameCompare> OptionsMap;


### PR DESCRIPTION
In this release, support for Chess960 is added.
Furthermore, this version introduces a new NNUE architecture and some search improvements. In self-play, an improvement of roughly 100 Elo has been observed, and the new version wins on average 16 more game pairs than it loses.

LTC vs pawn 2.0
Games: 2000/2000 Elo diff: 103.16 [94.59, 111.86] (95%)
W: 628 L: 51 D: 1321 Draw ratio: 66.0%
Pntl: [0, 30, 481, 371, 118]

No functional change