### PR TITLE
Update Makefile and tests

### DIFF
--- a/.github/workflows/pawn-tests.yaml
+++ b/.github/workflows/pawn-tests.yaml
@@ -79,9 +79,11 @@ jobs:
           msystem: ${{matrix.config.sys}}
           install: make git diffutils ${{matrix.config.packages}}
       - name: Fetch bench signature
-        run: "git log HEAD | grep 'Bench: ' | head -n 1 | awk '{print $2}' > bench.sig_ref"
+        run: |
+          git log HEAD | grep 'Bench: ' | head -n 1 | awk '{print $2}' > bench.sig_ref
       - name: Build pawn
-        run: "make"
+        run: |
+          make -j4
       - name: Run bench
         run: |
           build/pawn bench > bench.out 2>&1
@@ -90,7 +92,30 @@ jobs:
         run: |
           cat bench.out | grep 'Nodes searched:' | awk '{print $3}' > bench.sig
           cmp bench.sig bench.sig_ref
-      - name: Run tests
+      - name: Run bench - debug build
+        run: |
+          make -B -j4 DEBUG=1
+          build/pawn bench
+      - name: Run bench - AddressSanitizer
+        run: |
+          make -B -j4 DEBUG=2 SANITIZER=address
+          build/pawn bench
+      - name: Run bench - UndefinedBehaviorSanitizer
+        run: |
+          make -B -j4 DEBUG=2 SANITIZER=undefined
+          build/pawn bench
+      - name: Run bench - ThreadSanitizer
+        run: |
+          make -B -j4 DEBUG=2 SANITIZER=thread
+          TSAN_OPTIONS="suppressions=test/suppressions.tsan" build/pawn bench 13 4 16
+      - name: Run small bench - valgrind (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt update
+          sudo apt install valgrind
+          make -B -j4 DEBUG=2
+          valgrind --leak-check=full build/pawn bench 10
+      - name: Run internal tests
         run: |
           build/pawn test > test.out
           cat test.out

--- a/.github/workflows/pawn-tests.yaml
+++ b/.github/workflows/pawn-tests.yaml
@@ -69,7 +69,7 @@ jobs:
         shell: ${{ matrix.config.shell }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Prepare Windows with MSYS2
@@ -107,7 +107,7 @@ jobs:
     needs: build
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Install dependencies

--- a/.github/workflows/pawn-tests.yaml
+++ b/.github/workflows/pawn-tests.yaml
@@ -98,15 +98,15 @@ jobs:
           build/pawn bench
       - name: Run bench - AddressSanitizer
         run: |
-          make -B -j4 DEBUG=2 SANITIZER=address
+          make -B -j4 DEBUG=2 SANITIZE=address
           build/pawn bench
       - name: Run bench - UndefinedBehaviorSanitizer
         run: |
-          make -B -j4 DEBUG=2 SANITIZER=undefined
+          make -B -j4 DEBUG=2 SANITIZE=undefined
           build/pawn bench
       - name: Run bench - ThreadSanitizer
         run: |
-          make -B -j4 DEBUG=2 SANITIZER=thread
+          make -B -j4 DEBUG=2 SANITIZE=thread
           TSAN_OPTIONS="suppressions=test/suppressions.tsan" build/pawn bench 13 4 16
       - name: Run small bench - valgrind (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/pawn-tests.yaml
+++ b/.github/workflows/pawn-tests.yaml
@@ -92,6 +92,28 @@ jobs:
         run: |
           cat bench.out | grep 'Nodes searched:' | awk '{print $3}' > bench.sig
           cmp bench.sig bench.sig_ref
+      - name: Run tests
+        run: |
+          build/pawn test > test.out
+          cat test.out
+          grep -q 'All tests passed' test.out
+  sanitisers:
+    name: Sanitisers
+    runs-on: ubuntu-latest
+    env:
+      CC: gcc
+      CXX: g++
+      shell: bash
+    needs: build
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install valgrind
       - name: Run bench - debug build
         run: |
           make -B -j4 DEBUG=1
@@ -104,19 +126,13 @@ jobs:
         run: |
           make -B -j4 DEBUG=2 SANITIZE=undefined
           build/pawn bench
-      - name: Run bench - ThreadSanitizer
+      - name: Run small bench - ThreadSanitizer
         run: |
           make -B -j4 DEBUG=2 SANITIZE=thread
-          TSAN_OPTIONS="suppressions=test/suppressions.tsan" build/pawn bench 13 4 16
-      - name: Run small bench - valgrind (Linux)
-        if: runner.os == 'Linux'
+          TSAN_OPTIONS="suppressions=test/suppressions.tsan" build/pawn bench 11 4 64
+      - name: Run small bench - valgrind
         run: |
           sudo apt update
           sudo apt install valgrind
           make -B -j4 DEBUG=2
-          valgrind --leak-check=full build/pawn bench 10
-      - name: Run internal tests
-        run: |
-          build/pawn test > test.out
-          cat test.out
-          grep -q 'All tests passed' test.out
+          valgrind --leak-check=full build/pawn bench 11

--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,33 @@ SRC_DIR=src
 # Default arch
 ARCH = native
 
-# Compiler flags
-COMMON = -Wall -Isrc/syzygy/Fathom/src -O3 -flto -march=$(ARCH)
-CFLAGS = $(COMMON)
-CXXFLAGS = $(COMMON) -std=c++17
-LDFLAGS = -flto -march=$(ARCH)
+# Base compiler flags
+COMMON := -Wall -Isrc/syzygy/Fathom/src -march=$(ARCH)
+LDFLAGS := -march=$(ARCH)
+
+# Debug or release build
+# DEBUG=1: Build with debug symbols and no optimisations
+# DEBUG=2: Build with debug symbols and some optimisations
+# Anything else: Build with full optimisations
+ifeq ($(DEBUG), 1)
+	COMMON += -g
+else ifeq ($(DEBUG), 2)
+	COMMON += -g -O1 -fno-inline -fno-omit-frame-pointer
+else
+	COMMON += -O3 -flto
+	LDFLAGS += -flto
+endif
+
+# Sanitisers
+ifdef SANITIZE
+	COMMON += -fsanitize=$(SANITIZE)
+	LDFLAGS += -fsanitize=$(SANITIZE)
+endif
+
+# Update compiler flags
+# Fathom has warnings that are raised with -Wextra, so we ignore them for C files
+CFLAGS := $(COMMON)
+CXXFLAGS := $(COMMON) -std=c++17 -Wextra
 
 # Windows-specific stuff
 ifeq ($(OS), Windows_NT)

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ ifeq ($(DEBUG), 1)
 else ifeq ($(DEBUG), 2)
 	COMMON += -g -O1 -fno-inline -fno-omit-frame-pointer
 else
-	COMMON += -O3 -flto
+	COMMON += -O3 -DNDEBUG -flto
 	LDFLAGS += -flto
 endif
 

--- a/src/Bitboard.hpp
+++ b/src/Bitboard.hpp
@@ -27,7 +27,6 @@ public:
 
     // Constructors
     constexpr Bitboard() : m_data(0) {}
-    constexpr Bitboard(const Bitboard&) = default;
     constexpr Bitboard(uint64_t data) : m_data(data) {}
 
 
@@ -398,7 +397,7 @@ namespace Bitboards
     extern Bitboard between_squares[NUM_SQUARES][NUM_SQUARES];
 
     template <PieceType PIECE_TYPE>
-    Bitboard get_attacks(Square square, Bitboard occupancy)
+    Bitboard get_attacks(Square square, [[maybe_unused]] Bitboard occupancy)
     {
         return pseudo_attacks[PIECE_TYPE][square];
     }

--- a/src/Hash.hpp
+++ b/src/Hash.hpp
@@ -91,7 +91,7 @@ public:
     inline bool query(Age age, Hash hash, TranspositionEntry** entry)
     {
         *entry = this;
-        if (hash == this->hash())
+        if (!empty() && hash == this->hash())
         {
             // Bump up the age of this entry
             m_type = gen_type(age, type());
@@ -132,7 +132,6 @@ template<typename Entry>
 class HashTable
 {
     std::vector<Entry> m_table;
-    std::size_t m_full;
     Age m_age;
 
     static std::size_t size_from_mb(std::size_t mb)   { return mb * 1024 / sizeof(Entry) * 1024 + 1; }
@@ -147,7 +146,6 @@ public:
 
     HashTable(std::size_t size, bool size_in_mb = true)
         : m_table(size_in_mb ? size_from_mb(size) : size),
-          m_full(0),
           m_age(0)
     {}
 
@@ -160,14 +158,11 @@ public:
     template<typename... Args>
     void store(Hash hash, Args... args)
     {
-        auto& entry = m_table[index(hash)];
-        m_full += entry.empty();
-        entry.store(m_age, hash, args...);
+        m_table[index(hash)].store(m_age, hash, args...);
     }
 
     void clear()
     {
-        m_full = 0;
         m_age = 0;
         std::fill(m_table.begin(), m_table.end(), Entry());
     }
@@ -182,12 +177,14 @@ public:
     void resize(std::size_t size_mb)
     {
         m_table = std::vector<Entry>(size_from_mb(size_mb));
-        m_full = 0;
     }
 
     int hashfull() const
     {
-        return m_full * 1000 / m_table.size();
+        int count = 0;
+        for (int i = 0; i < 1000; i++)
+            count += !m_table[index(i)].empty();
+        return count;
     }
 
     void prefetch(Hash hash)

--- a/src/Hash.hpp
+++ b/src/Hash.hpp
@@ -85,13 +85,13 @@ class TranspositionEntry
 
 public:
     TranspositionEntry()
-        : m_type(gen_type(0, EntryType::EMPTY))
+        : m_hash(0), m_type(gen_type(0, EntryType::EMPTY))
     {}
 
     inline bool query(Age age, Hash hash, TranspositionEntry** entry)
     {
         *entry = this;
-        if (!empty() && hash == this->hash())
+        if (hash == this->hash())
         {
             // Bump up the age of this entry
             m_type = gen_type(age, type());

--- a/src/Position.hpp
+++ b/src/Position.hpp
@@ -689,7 +689,6 @@ struct MoveInfo
 {
     Move move;
     bool extended;
-    bool reduced;
 };
 
 

--- a/src/UCI.cpp
+++ b/src/UCI.cpp
@@ -147,23 +147,23 @@ namespace UCI
 
             // Switch on the received token
             if (token == "quit")
-                quit(stream);
+                quit();
             else if (token == "stop")
-                stop(stream);
+                stop();
             else if (token == "uci")
-                uci(stream);
+                uci();
             else if (token == "setoption")
                 setoption(stream);
             else if (token == "isready")
-                isready(stream);
+                isready();
             else if (token == "ucinewgame")
-                ucinewgame(stream);
+                ucinewgame();
             else if (token == "go")
                 go(stream);
             else if (token == "position")
                 position(stream);
             else if (token == "ponderhit")
-                ponderhit(stream);
+                ponderhit();
 
             // Non-UCI commands
             else if (token == "board")
@@ -209,7 +209,7 @@ namespace UCI
 
 
 
-    void uci(Stream& stream)
+    void uci()
     {
         std::cout << "id name " << VERSION << std::endl;
         std::cout << "id author ruicoelhopedro" << std::endl;
@@ -300,14 +300,14 @@ namespace UCI
 
 
 
-    void stop(Stream& stream)
+    void stop()
     {
         pool->stop();
     }
 
 
 
-    void quit(Stream& stream)
+    void quit()
     {
         pool->stop();
     }
@@ -352,14 +352,14 @@ namespace UCI
 
 
 
-    void ponderhit(Stream& stream)
+    void ponderhit()
     {
         pool->ponderhit();
     }
 
 
 
-    void ucinewgame(Stream& stream)
+    void ucinewgame()
     {
         ttable.clear();
         pool->clear();
@@ -367,7 +367,7 @@ namespace UCI
 
 
 
-    void isready(Stream& stream)
+    void isready()
     {
         // Mandatory readyok output when all set
         std::cout << "readyok" << std::endl;

--- a/src/UCI.hpp
+++ b/src/UCI.hpp
@@ -100,14 +100,14 @@ namespace UCI
 
     void main_loop(std::string args);
     void setoption(Stream& stream);
-    void uci(Stream& stream);
+    void uci();
     void go(Stream& stream);
-    void stop(Stream& stream);
-    void quit(Stream& stream);
+    void stop();
+    void quit();
     void position(Stream& stream);
-    void ponderhit(Stream& stream);
-    void ucinewgame(Stream& stream);
-    void isready(Stream& stream);
+    void ponderhit();
+    void ucinewgame();
+    void isready();
 
     void bench(Stream& stream);
 

--- a/test/suppressions.tsan
+++ b/test/suppressions.tsan
@@ -1,0 +1,10 @@
+race:TranspositionEntry::query
+race:TranspositionEntry::store
+race:TranspositionEntry::hash
+race:TranspositionEntry::depth
+race:TranspositionEntry::type
+race:TranspositionEntry::score
+race:TranspositionEntry::hash_move
+race:TranspositionEntry::static_eval
+race:HashTable<TranspositionEntry>::store
+race:HashTable<TranspositionEntry>::query


### PR DESCRIPTION
Several updates on the CI tests to include debugging with sanitisers. The following steps have been added for a single Ubuntu worker:
- Run bench without optimisations
- Run bench with the address sanitiser
- Run bench with the undefined behaviour sanitiser
- Run small bench (depth 11) with the thread sanitiser (4 threads)
- Run small bench (depth 11) with valgrind

To automate build flags, options for debug mode and sanitisers have been to the Makefile.
Also, `-Wextra` has been added, and some minor fixes have been made to silence some warnings.
Finally, the computation of `hashfull` has been updated to fix a possible race condition and the hash of the TT entries are initialised to zero (to prevent warnings from valgrind).

Non-regression STC:
LLR:  2.94/2.94<-6.00, 0.00> Elo diff: 1.90 [-1.49, 5.29] (95%)         
Games: 8238 W: 1024 L: 979 D: 6235 Draw ratio: 75.7% 
Pntl: [45, 640, 2703, 687, 44]

No functional change