### PR TITLE
Refactor global variables and thread model

### DIFF
--- a/src/Hash.cpp
+++ b/src/Hash.cpp
@@ -1,4 +1,0 @@
-#include "Hash.hpp"
-
-HashTable<TranspositionEntry> ttable;
-HashTable<PerftEntry> perft_table;

--- a/src/Hash.hpp
+++ b/src/Hash.hpp
@@ -193,6 +193,5 @@ public:
     }
 };
 
-
-extern HashTable<TranspositionEntry> ttable;
-extern HashTable<PerftEntry> perft_table;
+using TranspositionTable = HashTable<TranspositionEntry>;
+using PerftTable = HashTable<PerftEntry>;

--- a/src/NNUE.cpp
+++ b/src/NNUE.cpp
@@ -67,7 +67,7 @@ namespace NNUE
 
     
 
-    Feature Accumulator::get_feature(PieceType p, Square s, Square ks, Turn pt, Turn kt) const
+    Feature Accumulator::get_feature(PieceType p, Square s, Square ks, Turn pt, Turn kt)
     {
         // Vertical mirror for black kings
         if (kt == BLACK)

--- a/src/NNUE.hpp
+++ b/src/NNUE.hpp
@@ -35,7 +35,7 @@ namespace NNUE
 
         void clear();
 
-        Feature get_feature(PieceType p, Square s, Square ks, Turn pt, Turn kt) const;
+        static Feature get_feature(PieceType p, Square s, Square ks, Turn pt, Turn kt);
 
         void push(PieceType p, Square s, Square ks, Turn pt, Turn kt);
 
@@ -51,8 +51,6 @@ namespace NNUE
 
         bool operator!=(const Accumulator& other) const;
     };
-
-    extern const Net* nnue_net;
 
     void init();
 

--- a/src/Search.cpp
+++ b/src/Search.cpp
@@ -143,7 +143,7 @@ namespace Search
              :                                         BoundType::LOWER_BOUND; // Blessed loss
     }
 
-    void MultiPVData::write_pv(const Board& board, int index, uint64_t nodes, uint64_t tb_hits, double elapsed) const
+    void MultiPVData::write_pv(const Board& board, int index, int hashfull, uint64_t nodes, uint64_t tb_hits, double elapsed) const
     {
         // Don't write if PV line is incomplete
         if (search_bound == BoundType::NO_BOUND)
@@ -167,7 +167,7 @@ namespace Search
         // Nodes, nps, hashful and timing
         std::cout << " nodes "    << nodes;
         std::cout << " nps "      << static_cast<int>(nodes / elapsed);
-        std::cout << " hashfull " << ttable.hashfull();
+        std::cout << " hashfull " << hashfull;
         std::cout << " tbhits "   << tb_hits;
         std::cout << " time "     << std::max(1, static_cast<int>(elapsed * 1000));
 
@@ -344,6 +344,7 @@ namespace Search
         const Turn Turn = position.get_turn();
         const Depth Ply = data.ply();
         CurrentHistory history = data.histories.get(position);
+        TranspositionTable& ttable = data.thread().pool().tt();
 
         if (PvNode)
         {
@@ -740,6 +741,7 @@ namespace Search
         const bool InCheck = position.in_check();
         const Turn Turn = position.get_turn();
         const Depth Ply = data.ply();
+        TranspositionTable& ttable = data.thread().pool().tt();
 
         if (PvNode)
         {

--- a/src/Search.hpp
+++ b/src/Search.hpp
@@ -116,7 +116,7 @@ namespace Search
 
         Score score() const;
         BoundType bound() const;
-        void write_pv(const Board& board, int index, uint64_t nodes, uint64_t tb_hits, double elapsed) const;
+        void write_pv(const Board& board, int index, int hashfull, uint64_t nodes, uint64_t tb_hits, double elapsed) const;
     };
 
 
@@ -185,14 +185,9 @@ namespace Search
     bool legality_tests(Position& position, MoveList& move_list);
 
 
-    template<bool OUTPUT, bool USE_ORDER = false, bool TT = false, bool LEGALITY = false, bool VALIDITY = false>
+    template<bool OUTPUT, bool USE_ORDER = false, bool LEGALITY = false, bool VALIDITY = false>
     int64_t perft(Position& position, Depth depth, Histories& hists)
     {
-        // TT lookup
-        PerftEntry* entry = nullptr;
-        if (TT && perft_table.query(position.hash(), &entry) && entry->depth() == depth)
-            return entry->n_nodes();
-
         // Move generation
         int64_t n_nodes = 0;
         auto move_list = position.generate_moves(MoveGenType::LEGAL);
@@ -220,7 +215,7 @@ namespace Search
                 if (depth > 1)
                 {
                     position.make_move(move);
-                    count = perft<false, USE_ORDER, TT, LEGALITY, VALIDITY>(position, depth - 1, hists);
+                    count = perft<false, USE_ORDER, LEGALITY, VALIDITY>(position, depth - 1, hists);
                     position.unmake_move();
                 }
                 n_nodes += count;
@@ -244,7 +239,7 @@ namespace Search
                         return 0;
 
                     position.make_move(move);
-                    count = perft<false, USE_ORDER, TT, LEGALITY, VALIDITY>(position, depth - 1, hists);
+                    count = perft<false, USE_ORDER, LEGALITY, VALIDITY>(position, depth - 1, hists);
                     position.unmake_move();
 
                     n_nodes += count;
@@ -261,10 +256,6 @@ namespace Search
                         std::cout << position.board().to_uci(move) << ": " << 1 << std::endl;
             }
         }
-
-        // TT storing
-        if (TT)
-            perft_table.store(position.hash(), depth, n_nodes);
 
         return n_nodes;
     }

--- a/src/Tests.cpp
+++ b/src/Tests.cpp
@@ -156,11 +156,8 @@ namespace Tests
 
     void bench(Search::Limits limits, int threads, int hash)
     {
-        // Resize thread pool and hash
-        pool->resize(threads);
-        ttable.resize(hash);
-        pool->clear();
-        ttable.clear();
+        // Create a thread pool with the given options
+        ThreadPool pool(threads, hash);
 
         // Start master timer
         Search::Timer time;
@@ -171,7 +168,7 @@ namespace Tests
 
         // Loop over each position
         int i = 0;
-        Position& pos = pool->position();
+        Position& pos = pool.position();
         std::vector<std::string> fens = bench_suite();
         for (auto fen : fens)
         {
@@ -181,16 +178,16 @@ namespace Tests
             // Update position
             pos = Position(fen);
             pos.set_init_ply();
-            pool->update_position_threads();
+            pool.update_position_threads();
             std::cerr << "\nPosition " << (++i) << "/" << fens.size() << ": " << fen << std::endl;
 
             // Start searching and wait for completion
             Search::Timer pos_timer;
-            pool->search(pos_timer, limits);
-            pool->wait();
+            pool.search(pos_timer, limits);
+            pool.wait();
 
             // Update number of nodes
-            nodes += pool->nodes_searched();
+            nodes += pool.nodes_searched();
         }
 
         // Output bench stats
@@ -200,10 +197,8 @@ namespace Tests
         std::cerr << "Elapsed time (s): " << std::setw(7) << elapsed   << std::endl;
         std::cerr << "Nodes per second: " << uint64_t(nodes / elapsed) << std::endl;
 
-        // Restore initial options, thread pool and hash
+        // Restore initial options
         UCI::Options::UCI_Chess960 = Chess960;
-        pool->resize(UCI::Options::Threads);
-        ttable.resize(UCI::Options::Hash);
     }
 
 

--- a/src/Tests.hpp
+++ b/src/Tests.hpp
@@ -37,17 +37,13 @@ namespace Tests
     void bench(Search::Limits limits, int threads, int hash);
 
 
-    template<bool USE_ORDER, bool TT, bool LEGALITY, bool VALIDITY>
+    template<bool USE_ORDER, bool LEGALITY, bool VALIDITY>
     int perft_techniques_tests()
     {
         // Store initial state
         bool Chess960 = UCI::Options::UCI_Chess960;
 
         auto tests = test_suite();
-
-        // Allocate TT
-        if (TT)
-            perft_table.resize(16);
 
         int n_failed = 0;
         for (auto& test : tests)
@@ -59,7 +55,7 @@ namespace Tests
             auto hists = std::make_unique<Histories>();
             Depth depth = test.depth() - 1 - 2 * (LEGALITY || VALIDITY);
             auto result_base = Search::perft<false>(pos, depth, *hists);
-            auto result_test = Search::template perft<false, USE_ORDER, TT, LEGALITY, VALIDITY>(pos, depth, *hists);
+            auto result_test = Search::template perft<false, USE_ORDER, LEGALITY, VALIDITY>(pos, depth, *hists);
             if (result_base == result_test)
             {
                 std::cout << "[ OK ] " << test.fen() << " (" << result_test << ")" << std::endl;
@@ -70,10 +66,6 @@ namespace Tests
                 n_failed++;
             }
         }
-
-        // Deallocate TT
-        if (TT)
-            perft_table.resize(0);
 
         UCI::Options::UCI_Chess960 = Chess960;
         std::cout << "\nFailed/total tests: " << n_failed << "/" << tests.size() << std::endl;

--- a/src/Thread.hpp
+++ b/src/Thread.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "Types.hpp"
 #include "Move.hpp"
 #include "Position.hpp"
@@ -83,6 +85,7 @@ public:
 class ThreadPool
 {
     Position m_position;
+    TranspositionTable m_tt;
     std::vector<std::unique_ptr<Thread>> m_threads;
 
     void send_signal(ThreadStatus signal);
@@ -94,7 +97,9 @@ protected:
     std::atomic<ThreadStatus> m_status;
 
 public:
-    ThreadPool();
+    ThreadPool(int n_threads, int hash_size_mb);
+
+    virtual ~ThreadPool();
 
     void resize(int n_threads);
 
@@ -131,7 +136,5 @@ public:
     Thread* get_best_thread() const;
 
     inline Thread& front() { return *(m_threads.front()); }
+    inline TranspositionTable& tt() { return m_tt; }
 };
-
-
-extern ThreadPool* pool;

--- a/src/UCI.hpp
+++ b/src/UCI.hpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <variant>
 #include "Move.hpp"
+#include "Thread.hpp"
 
 
 namespace UCI
@@ -77,6 +78,7 @@ namespace UCI
     };
 
 
+    extern std::unique_ptr<ThreadPool> pool;
     extern std::map<std::string, Option, OptionNameCompare> OptionsMap;
 
 
@@ -95,7 +97,7 @@ namespace UCI
     }
 
 
-    void init_options();
+    void init();
 
 
     void main_loop(std::string args);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,7 @@
 #include "syzygy/syzygy.hpp"
 #include <chrono>
 #include <sstream>
+#include <memory>
 
 int main(int argc, char** argv)
 {
@@ -16,9 +17,7 @@ int main(int argc, char** argv)
     Zobrist::build_rnd_hashes();
     NNUE::init();
     Syzygy::init();
-    UCI::init_options();
-    ttable = HashTable<TranspositionEntry>(16);
-    pool = new ThreadPool();
+    UCI::init();
 
     // Handle passed arguments
     std::stringstream ss;
@@ -28,6 +27,5 @@ int main(int argc, char** argv)
 
     UCI::main_loop(ss.str());
 
-    pool->kill_threads();
     NNUE::clean();
 }


### PR DESCRIPTION
Refactor most of the search-related global variables into the ThreadPool.
While there, simplify the TT code and remove the PerftTable tests.
Also, use smart pointers for the ThreadPool object.

Non-regression STC:
LLR:  2.98/2.94<-6.00, 0.00> Elo diff: -0.73 [-2.20, 0.75] (95%)
Games: 43095 W: 5266 L: 5355 D: 32474 Draw ratio: 75.4%
Pntl: [230, 3508, 14153, 3434, 222]

No functional change