### PR TITLE
Fix Valgrind test

### DIFF
--- a/.github/workflows/pawn-tests.yaml
+++ b/.github/workflows/pawn-tests.yaml
@@ -134,5 +134,5 @@ jobs:
         run: |
           sudo apt update
           sudo apt install valgrind
-          make -B -j4 DEBUG=2
+          make -B -j4 DEBUG=2 ARCH=haswell
           valgrind --leak-check=full --error-exitcode=1 build/pawn bench 11

--- a/.github/workflows/pawn-tests.yaml
+++ b/.github/workflows/pawn-tests.yaml
@@ -132,7 +132,5 @@ jobs:
           TSAN_OPTIONS="suppressions=test/suppressions.tsan" build/pawn bench 11 4 64
       - name: Run small bench - valgrind
         run: |
-          sudo apt update
-          sudo apt install valgrind
           make -B -j4 DEBUG=2 ARCH=haswell
           valgrind --leak-check=full --error-exitcode=1 build/pawn bench 11


### PR DESCRIPTION
Using `ARCH=native` is dangerous for the Valgrind test, since unsupported AVX512 instructions may be emmited by the compiler. This downgrades the target architecture to `haswell` for the Valgrind test.

No functional change